### PR TITLE
Respect system rotation settings in the PWA

### DIFF
--- a/src/server/controllers/http/misc/pwa-router.ts
+++ b/src/server/controllers/http/misc/pwa-router.ts
@@ -11,7 +11,6 @@ export function pwaRouter(): Router {
             name: seo.title,
             description: seo.description,
             lang: 'en',
-            orientation: 'any',
             start_url: '/',
             theme_color: '#DC3545',
             background_color: '#212529',


### PR DESCRIPTION
Currently, on Android, the PWA is rotated regardless of the settings of the system. AFAIK `orientation: any` should be used sparingly.